### PR TITLE
Fix building on non-x86 compatible archs

### DIFF
--- a/heim-virt/Cargo.toml
+++ b/heim-virt/Cargo.toml
@@ -19,7 +19,7 @@ heim-common = { version = "0.0.8", path = "../heim-common" }
 heim-runtime = { version = "0.0.4", path = "../heim-runtime" }
 cfg-if = "0.1.9"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(target_os = "linux", any(target_arch="x86", target_arch="x86_64")))'.dependencies]
 raw-cpuid = "7.0.3"
 
 [dev-dependencies]

--- a/heim-virt/src/sys/linux/cpuid.rs
+++ b/heim-virt/src/sys/linux/cpuid.rs
@@ -1,3 +1,4 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use raw_cpuid::{CpuId, Hypervisor};
 
 use crate::Virtualization;


### PR DESCRIPTION
I am using an ARM arch, so the commit fixes project building under non-x86 compatibility architectures by disabling `raw-cpuid` crate that may work on x86\amd64 archs only.