### PR TITLE
Fix building on arm\powerpc

### DIFF
--- a/heim-virt/src/sys/linux/device_tree.rs
+++ b/heim-virt/src/sys/linux/device_tree.rs
@@ -1,7 +1,7 @@
 use std::marker::Unpin;
 use std::path::Path;
 
-use heim_common::prelude::{future, Future, FutureExt, StreamExt, TryStreamExt};
+use heim_common::prelude::{future, Future, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use heim_runtime::fs;
 
 use crate::Virtualization;


### PR DESCRIPTION
Fixed compile error:
```
error[E0599]: no method named `or_else` found for type `impl std::future::Future` in the current scope
  --> heim-virt/src/sys/linux/device_tree.rs:59:40
```
