### PR TITLE
Io process counters

### DIFF
--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -54,7 +54,7 @@ features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"
-darwin-libproc = {git = "https://github.com/heim-rs/darwin-libproc.git", branch="pid-rusage"}
+darwin-libproc = "0.2.0"
 
 [dev-dependencies]
 heim-derive = { version = "0.1.0-beta.1", path = "../heim-derive" }

--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -54,7 +54,7 @@ features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"
-darwin-libproc = "0.1.1"
+darwin-libproc = {git = "https://github.com/heim-rs/darwin-libproc.git", branch="pid-rusage"}
 
 [dev-dependencies]
 heim-derive = { version = "0.1.0-beta.1", path = "../heim-derive" }

--- a/heim-process/src/os/linux/io_counters.rs
+++ b/heim-process/src/os/linux/io_counters.rs
@@ -1,76 +1,68 @@
-use std::fmt;
+use heim_common::units::Information;
 
-use heim_common::units::{information, Information};
-
-/// Process IO statistics.
+/// Linux-specific extension to process [IoCounters] information.
 ///
-/// For additional information of data provided, see [proc.txt] documentation,
-/// section 3.3 "/proc/<pid>/io - Display the IO accounting fields".
-///
-/// [proc.txt]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-#[derive(Default)]
-pub struct IoCounters {
-    pub(crate) rchar: u64,
-    pub(crate) wchar: u64,
-    pub(crate) syscr: u64,
-    pub(crate) syscw: u64,
-    pub(crate) read_bytes: u64,
-    pub(crate) write_bytes: u64,
-    pub(crate) cancelled_write_bytes: u64,
+/// [IoCounters]: ../../struct.IoCounters.html
+pub trait IoCountersExt {
+    /// The number of bytes which this task has caused to be read from storage.
+    fn chars_read(&self) -> Information;
+    /// The number of bytes which this task has caused, or shall cause to be written to disk.
+    fn chars_written(&self) -> Information;
+    /// Attempt to count the number of read I/O operations,
+    /// i.e. syscalls like `read()` and `pread()`.
+    fn read_syscalls(&self) -> u64;
+    /// Attempt to count the number of write I/O operations,
+    /// i.e. syscalls like `write()` and `pwrite()`.
+    fn write_syscalls(&self) -> u64;
+    // Attempt to count the number of bytes which this process really did cause to
+    /// be fetched from the storage layer.
+    fn bytes_read(&self) -> Information;
+    /// Attempt to count the number of bytes which this process caused to be sent to
+    /// the storage layer.
+    fn bytes_written(&self) -> Information;
+    /// The number of bytes which this process caused to not happen,
+    /// by truncating pagecache.
+    fn cancelled_write_bytes(&self) -> Information;
 }
 
-impl IoCounters {
+impl IoCountersExt for crate::process::IoCounters {
     /// The number of bytes which this task has caused to be read from storage.
-    pub fn chars_read(&self) -> Information {
-        Information::new::<information::byte>(self.rchar)
+    fn chars_read(&self) -> Information {
+        self.as_ref().chars_read()
     }
 
     /// The number of bytes which this task has caused, or shall cause to be written to disk.
-    pub fn chars_written(&self) -> Information {
-        Information::new::<information::byte>(self.wchar)
+    fn chars_written(&self) -> Information {
+        self.as_ref().chars_written()
     }
 
     /// Attempt to count the number of read I/O operations,
     /// i.e. syscalls like `read()` and `pread()`.
-    pub fn read_syscalls(&self) -> u64 {
-        self.syscr
+    fn read_syscalls(&self) -> u64 {
+        self.as_ref().read_syscalls()
     }
 
     /// Attempt to count the number of write I/O operations,
     /// i.e. syscalls like `write()` and `pwrite()`.
-    pub fn write_syscalls(&self) -> u64 {
-        self.syscw
+    fn write_syscalls(&self) -> u64 {
+        self.as_ref().write_syscalls()
     }
 
     /// Attempt to count the number of bytes which this process really did cause to
     /// be fetched from the storage layer.
-    pub fn bytes_read(&self) -> Information {
-        Information::new::<information::byte>(self.read_bytes)
+    fn bytes_read(&self) -> Information {
+        self.as_ref().bytes_read()
     }
 
     /// Attempt to count the number of bytes which this process caused to be sent to
     /// the storage layer.
-    pub fn bytes_written(&self) -> Information {
-        Information::new::<information::byte>(self.write_bytes)
+    fn bytes_written(&self) -> Information {
+        self.as_ref().bytes_written()
     }
 
     /// The number of bytes which this process caused to not happen,
     /// by truncating pagecache.
-    pub fn cancelled_write_bytes(&self) -> Information {
-        Information::new::<information::byte>(self.cancelled_write_bytes)
-    }
-}
-
-impl fmt::Debug for IoCounters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("IoCounters")
-            .field("chars_read", &self.chars_read())
-            .field("chars_written", &self.chars_written())
-            .field("read_syscalls", &self.read_syscalls())
-            .field("write_syscalls", &self.write_syscalls())
-            .field("bytes_read", &self.bytes_read())
-            .field("bytes_written", &self.bytes_written())
-            .field("cancelled_write_bytes", &self.cancelled_write_bytes())
-            .finish()
+    fn cancelled_write_bytes(&self) -> Information {
+        self.as_ref().cancelled_write_bytes()
     }
 }

--- a/heim-process/src/os/linux/mod.rs
+++ b/heim-process/src/os/linux/mod.rs
@@ -7,7 +7,7 @@ use crate::ProcessResult;
 mod io_counters;
 mod memory;
 
-pub use self::io_counters::IoCounters;
+pub use self::io_counters::IoCountersExt;
 pub use self::memory::MemoryExt;
 
 /// Linux-specific extension to [Process]
@@ -15,12 +15,6 @@ pub use self::memory::MemoryExt;
 /// [Process]: ../../struct.Process.html
 #[async_trait::async_trait]
 pub trait ProcessExt {
-    /// Returns future which resolves into process IO counters.
-    ///
-    /// Since `-> impl Trait` is not allowed yet in the trait methods,
-    /// this method returns boxed `Future`. This behavior will change later.
-    async fn io_counters(&self) -> ProcessResult<IoCounters>;
-
     /// Returns stream which yield this process [IO counters] for each network interface.
     ///
     /// Since `-> impl Trait` is not allowed yet in the trait methods,
@@ -36,10 +30,6 @@ pub trait ProcessExt {
 #[cfg(target_os = "linux")]
 #[async_trait::async_trait]
 impl ProcessExt for crate::Process {
-    async fn io_counters(&self) -> ProcessResult<IoCounters> {
-        self.as_ref().io_counters().await
-    }
-
     async fn net_io_counters(
         &self,
     ) -> ProcessResult<BoxStream<'_, ProcessResult<heim_net::IoCounters>>> {

--- a/heim-process/src/process/io_counters.rs
+++ b/heim-process/src/process/io_counters.rs
@@ -1,0 +1,17 @@
+use heim_common::prelude::wrap;
+use std::fmt;
+
+use crate::sys;
+
+/// IO information about the process.
+///
+/// See os-specific extensions also.
+pub struct IoCounters(sys::IoCounters);
+
+wrap!(IoCounters, sys::IoCounters);
+
+impl fmt::Debug for IoCounters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("IoCounters").finish()
+    }
+}

--- a/heim-process/src/process/io_counters.rs
+++ b/heim-process/src/process/io_counters.rs
@@ -1,3 +1,4 @@
+use heim_common::units::Information;
 use heim_common::prelude::wrap;
 use std::fmt;
 
@@ -10,8 +11,25 @@ pub struct IoCounters(sys::IoCounters);
 
 wrap!(IoCounters, sys::IoCounters);
 
+impl IoCounters {
+    /// Attempt to count the number of bytes which this process really did cause to
+    /// be fetched from the storage layer.
+    pub fn bytes_read(&self) -> Information {
+        self.as_ref().bytes_read()
+    }
+
+    /// Attempt to count the number of bytes which this process caused to be sent to
+    /// the storage layer.
+    pub fn bytes_written(&self) -> Information {
+        self.as_ref().bytes_written()
+    }
+}
+
 impl fmt::Debug for IoCounters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("IoCounters").finish()
+        f.debug_struct("IoCounters")
+        .field("bytes_read", &self.bytes_read())
+        .field("bytes_written", &self.bytes_written())
+        .finish()
     }
 }

--- a/heim-process/src/process/io_counters.rs
+++ b/heim-process/src/process/io_counters.rs
@@ -1,5 +1,5 @@
-use heim_common::units::Information;
 use heim_common::prelude::wrap;
+use heim_common::units::Information;
 use std::fmt;
 
 use crate::sys;
@@ -28,8 +28,8 @@ impl IoCounters {
 impl fmt::Debug for IoCounters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("IoCounters")
-        .field("bytes_read", &self.bytes_read())
-        .field("bytes_written", &self.bytes_written())
-        .finish()
+            .field("bytes_read", &self.bytes_read())
+            .field("bytes_written", &self.bytes_written())
+            .finish()
     }
 }

--- a/heim-process/src/process/mod.rs
+++ b/heim-process/src/process/mod.rs
@@ -245,9 +245,6 @@ impl Process {
     }
 
     /// Returns future which resolves into process IO counters.
-    ///
-    /// Since `-> impl Trait` is not allowed yet in the trait methods,
-    /// this method returns boxed `Future`. This behavior will change later.
     pub async fn io_counters(&self) -> ProcessResult<IoCounters> {
         self.as_ref().io_counters().await.map(Into::into)
     }

--- a/heim-process/src/process/mod.rs
+++ b/heim-process/src/process/mod.rs
@@ -11,6 +11,7 @@ mod command;
 mod cpu_times;
 mod cpu_usage;
 mod env;
+mod io_counters;
 mod memory;
 mod status;
 
@@ -18,6 +19,7 @@ pub use self::command::{Command, CommandIter};
 pub use self::cpu_times::CpuTime;
 pub use self::cpu_usage::CpuUsage;
 pub use self::env::{Environment, EnvironmentIter, IntoEnvironmentIter};
+pub use self::io_counters::IoCounters;
 pub use self::memory::Memory;
 pub use self::status::Status;
 
@@ -240,6 +242,14 @@ impl Process {
     /// If the process is already terminated, this method returns `Ok(())`.
     pub async fn wait(&self) -> ProcessResult<()> {
         self.as_ref().wait().await
+    }
+
+    /// Returns future which resolves into process IO counters.
+    ///
+    /// Since `-> impl Trait` is not allowed yet in the trait methods,
+    /// this method returns boxed `Future`. This behavior will change later.
+    pub async fn io_counters(&self) -> ProcessResult<IoCounters> {
+        self.as_ref().io_counters().await.map(Into::into)
     }
 }
 

--- a/heim-process/src/sys/linux/process/mod.rs
+++ b/heim-process/src/sys/linux/process/mod.rs
@@ -9,7 +9,6 @@ use heim_common::units::Time;
 use heim_runtime as rt;
 
 use super::{pid_exists, pids};
-use crate::os::linux::IoCounters;
 use crate::os::unix::Signal;
 use crate::sys::common::UniqueId;
 use crate::sys::unix::{pid_kill, pid_priority, pid_setpriority, pid_wait};
@@ -17,7 +16,7 @@ use crate::{Pid, ProcessError, ProcessResult, Status};
 
 mod procfs;
 
-pub use self::procfs::{Command, CommandIter, CpuTime, Environment, Memory};
+pub use self::procfs::{Command, CommandIter, CpuTime, Environment, IoCounters, Memory};
 
 #[derive(Debug)]
 pub struct Process {

--- a/heim-process/src/sys/linux/process/procfs/io.rs
+++ b/heim-process/src/sys/linux/process/procfs/io.rs
@@ -1,12 +1,86 @@
 use std::str::FromStr;
 
 use heim_common::prelude::*;
+use heim_common::units::{information, Information};
 use heim_common::utils::iter::TryIterator;
 use heim_common::Pid;
 use heim_runtime as rt;
+use std::fmt;
 
-use crate::os::linux::IoCounters;
 use crate::{ProcessError, ProcessResult};
+
+/// Process IO statistics.
+///
+/// For additional information of data provided, see [proc.txt] documentation,
+/// section 3.3 "/proc/<pid>/io - Display the IO accounting fields".
+///
+/// [proc.txt]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+#[derive(Default)]
+pub struct IoCounters {
+    rchar: u64,
+    wchar: u64,
+    syscr: u64,
+    syscw: u64,
+    read_bytes: u64,
+    write_bytes: u64,
+    cancelled_write_bytes: u64,
+}
+
+impl fmt::Debug for IoCounters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("IoCounters")
+            .field("chars_read", &self.chars_read())
+            .field("chars_written", &self.chars_written())
+            .field("read_syscalls", &self.read_syscalls())
+            .field("write_syscalls", &self.write_syscalls())
+            .field("bytes_read", &self.bytes_read())
+            .field("bytes_written", &self.bytes_written())
+            .field("cancelled_write_bytes", &self.cancelled_write_bytes())
+            .finish()
+    }
+}
+
+impl IoCounters {
+    /// The number of bytes which this task has caused to be read from storage.
+    pub fn chars_read(&self) -> Information {
+        Information::new::<information::byte>(self.rchar)
+    }
+
+    /// The number of bytes which this task has caused, or shall cause to be written to disk.
+    pub fn chars_written(&self) -> Information {
+        Information::new::<information::byte>(self.wchar)
+    }
+
+    /// Attempt to count the number of read I/O operations,
+    /// i.e. syscalls like `read()` and `pread()`.
+    pub fn read_syscalls(&self) -> u64 {
+        self.syscr
+    }
+
+    /// Attempt to count the number of write I/O operations,
+    /// i.e. syscalls like `write()` and `pwrite()`.
+    pub fn write_syscalls(&self) -> u64 {
+        self.syscw
+    }
+
+    /// Attempt to count the number of bytes which this process really did cause to
+    /// be fetched from the storage layer.
+    pub fn bytes_read(&self) -> Information {
+        Information::new::<information::byte>(self.read_bytes)
+    }
+
+    /// Attempt to count the number of bytes which this process caused to be sent to
+    /// the storage layer.
+    pub fn bytes_written(&self) -> Information {
+        Information::new::<information::byte>(self.write_bytes)
+    }
+
+    /// The number of bytes which this process caused to not happen,
+    /// by truncating pagecache.
+    pub fn cancelled_write_bytes(&self) -> Information {
+        Information::new::<information::byte>(self.cancelled_write_bytes)
+    }
+}
 
 impl FromStr for IoCounters {
     type Err = Error;

--- a/heim-process/src/sys/linux/process/procfs/mod.rs
+++ b/heim-process/src/sys/linux/process/procfs/mod.rs
@@ -8,6 +8,6 @@ mod statm;
 pub use self::command::{command, Command, CommandIter};
 pub use self::cpu_times::CpuTime;
 pub use self::env::{environment, Environment, IntoEnvironmentIter};
-pub use self::io::io;
+pub use self::io::{io, IoCounters};
 pub use self::stat::{stat, Stat};
 pub use self::statm::{stat_memory, Memory};

--- a/heim-process/src/sys/macos/process/io_counters.rs
+++ b/heim-process/src/sys/macos/process/io_counters.rs
@@ -1,0 +1,16 @@
+use heim_common::Pid;
+use std::fmt;
+use crate::ProcessResult;
+#[derive(Default)]
+pub struct IoCounters;
+
+
+pub async fn io(_pid: Pid) -> ProcessResult<IoCounters> {
+    ProcessResult::Ok(IoCounters)
+}
+
+impl fmt::Debug for IoCounters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("IoCounters").finish()
+    }
+}

--- a/heim-process/src/sys/macos/process/io_counters.rs
+++ b/heim-process/src/sys/macos/process/io_counters.rs
@@ -3,7 +3,6 @@ use heim_common::units::{information, Information};
 use heim_common::Pid;
 use std::fmt;
 use std::io;
-#[derive(Default)]
 pub struct IoCounters {
     read_bytes: u64,
     write_bytes: u64,

--- a/heim-process/src/sys/macos/process/io_counters.rs
+++ b/heim-process/src/sys/macos/process/io_counters.rs
@@ -1,7 +1,8 @@
 use heim_common::Pid;
 use heim_common::units::{information, Information};
 use std::fmt;
-use crate::ProcessResult;
+use std::io;
+use crate::{ProcessResult, ProcessError};
 #[derive(Default)]
 pub struct IoCounters{
     read_bytes: u64,
@@ -44,6 +45,7 @@ impl From<darwin_libproc::rusage_info_v2> for IoCounters{
 pub async fn io(pid: Pid) -> ProcessResult<IoCounters> {
     match darwin_libproc::pid_rusage::<darwin_libproc::rusage_info_v2>(pid){
         Ok(contents) => Ok(IoCounters::from(contents)),
+        Err(e) if e.kind() == io::ErrorKind::PermissionDenied => Err(ProcessError::AccessDenied(pid)),
         Err(e) => Err(e.into())
     }
 }

--- a/heim-process/src/sys/macos/process/io_counters.rs
+++ b/heim-process/src/sys/macos/process/io_counters.rs
@@ -1,16 +1,49 @@
 use heim_common::Pid;
+use heim_common::units::{information, Information};
 use std::fmt;
 use crate::ProcessResult;
 #[derive(Default)]
-pub struct IoCounters;
-
-
-pub async fn io(_pid: Pid) -> ProcessResult<IoCounters> {
-    ProcessResult::Ok(IoCounters)
+pub struct IoCounters{
+    read_bytes: u64,
+    write_bytes: u64
 }
 
 impl fmt::Debug for IoCounters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("IoCounters").finish()
+        f.debug_struct("IoCounters")
+            .field("bytes_read", &self.bytes_read())
+            .field("bytes_written", &self.bytes_written())
+            .finish()
+    }
+}
+
+
+impl IoCounters{
+    /// Attempt to count the number of bytes which this process really did cause to
+    /// be fetched from the storage layer.
+    pub fn bytes_read(&self) -> Information {
+        Information::new::<information::byte>(self.read_bytes)
+    }
+
+    /// Attempt to count the number of bytes which this process caused to be sent to
+    /// the storage layer.
+    pub fn bytes_written(&self) -> Information {
+        Information::new::<information::byte>(self.write_bytes)
+    }
+}
+
+impl From<darwin_libproc::rusage_info_v2> for IoCounters{
+    fn from(info: darwin_libproc::rusage_info_v2) -> IoCounters{
+        IoCounters{
+            read_bytes: info.ri_diskio_bytesread,
+            write_bytes: info.ri_diskio_bytesread,
+        }
+    }
+}
+
+pub async fn io(pid: Pid) -> ProcessResult<IoCounters> {
+    match darwin_libproc::pid_rusage::<darwin_libproc::rusage_info_v2>(pid){
+        Ok(contents) => Ok(IoCounters::from(contents)),
+        Err(e) => Err(e.into())
     }
 }

--- a/heim-process/src/sys/macos/process/mod.rs
+++ b/heim-process/src/sys/macos/process/mod.rs
@@ -11,7 +11,7 @@ use heim_common::prelude::*;
 use heim_common::sys::IntoTime;
 use heim_common::units::Time;
 
-use super::{bindings, pids, utils::catch_zombie};
+use super::{pids, bindings, utils::catch_zombie};
 use crate::os::unix::Signal;
 use crate::sys::common::UniqueId;
 use crate::sys::unix::{pid_kill, pid_priority, pid_setpriority, pid_wait};

--- a/heim-process/src/sys/macos/process/mod.rs
+++ b/heim-process/src/sys/macos/process/mod.rs
@@ -11,7 +11,7 @@ use heim_common::prelude::*;
 use heim_common::sys::IntoTime;
 use heim_common::units::Time;
 
-use super::{pids, bindings, utils::catch_zombie};
+use super::{bindings, pids, utils::catch_zombie};
 use crate::os::unix::Signal;
 use crate::sys::common::UniqueId;
 use crate::sys::unix::{pid_kill, pid_priority, pid_setpriority, pid_wait};
@@ -21,13 +21,13 @@ use crate::{Pid, ProcessError, ProcessResult, Status};
 mod command;
 mod cpu_times;
 mod env;
-mod memory;
 mod io_counters;
+mod memory;
 
 pub use self::command::{Command, CommandIter};
 pub use self::cpu_times::CpuTime;
-pub use self::memory::Memory;
 pub use self::io_counters::IoCounters;
+pub use self::memory::Memory;
 
 #[derive(Debug)]
 pub struct Process {

--- a/heim-process/src/sys/macos/process/mod.rs
+++ b/heim-process/src/sys/macos/process/mod.rs
@@ -22,10 +22,12 @@ mod command;
 mod cpu_times;
 mod env;
 mod memory;
+mod io_counters;
 
 pub use self::command::{Command, CommandIter};
 pub use self::cpu_times::CpuTime;
 pub use self::memory::Memory;
+pub use self::io_counters::IoCounters;
 
 #[derive(Debug)]
 pub struct Process {
@@ -160,6 +162,10 @@ impl Process {
 
     pub async fn wait(&self) -> ProcessResult<()> {
         pid_wait(self.pid).await
+    }
+
+    pub async fn io_counters(&self) -> ProcessResult<IoCounters> {
+        io_counters::io(self.pid).await
     }
 }
 

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -99,6 +99,22 @@ impl ProcessHandle<QueryLimitedInformation> {
         }
     }
 
+    pub fn io_counters(&self) -> ProcessResult<winnt::IO_COUNTERS> {
+        let mut counters = mem::MaybeUninit::<winnt::IO_COUNTERS>::uninit();
+
+        let result = unsafe{
+            winbase::GetProcessIoCounters(*self.handle, counters.as_mut_ptr())
+        };
+
+        if result == 0 {
+            Err(Error::last_os_error()
+                .with_ffi("GetProcessIoCounters")
+                .into())
+        } else{
+            unsafe { Ok(counters.assume_init()) }
+        }
+    }
+
     pub fn cpu_time(&self) -> ProcessResult<CpuTime> {
         let (_, _, kernel, user) = self.process_times()?;
 

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -102,15 +102,13 @@ impl ProcessHandle<QueryLimitedInformation> {
     pub fn io_counters(&self) -> ProcessResult<winnt::IO_COUNTERS> {
         let mut counters = mem::MaybeUninit::<winnt::IO_COUNTERS>::uninit();
 
-        let result = unsafe{
-            winbase::GetProcessIoCounters(*self.handle, counters.as_mut_ptr())
-        };
+        let result = unsafe { winbase::GetProcessIoCounters(*self.handle, counters.as_mut_ptr()) };
 
         if result == 0 {
             Err(Error::last_os_error()
                 .with_ffi("GetProcessIoCounters")
                 .into())
-        } else{
+        } else {
             unsafe { Ok(counters.assume_init()) }
         }
     }

--- a/heim-process/src/sys/windows/pids.rs
+++ b/heim-process/src/sys/windows/pids.rs
@@ -5,7 +5,7 @@ use winapi::um::minwinbase;
 use super::bindings;
 use crate::{Pid, ProcessError, ProcessResult};
 
-#[allow(clippy::identity_conversion)]
+#[allow(clippy::useless_conversion)]
 pub async fn pids() -> Result<impl Stream<Item = Result<Pid>>> {
     let pids = bindings::pids()?.into_iter().map(|pid| Ok(Pid::from(pid)));
 

--- a/heim-process/src/sys/windows/pids.rs
+++ b/heim-process/src/sys/windows/pids.rs
@@ -5,7 +5,7 @@ use winapi::um::minwinbase;
 use super::bindings;
 use crate::{Pid, ProcessError, ProcessResult};
 
-#[allow(clippy::useless_conversion)]
+#[allow(clippy::identity_conversion)]
 pub async fn pids() -> Result<impl Stream<Item = Result<Pid>>> {
     let pids = bindings::pids()?.into_iter().map(|pid| Ok(Pid::from(pid)));
 

--- a/heim-process/src/sys/windows/process/io_counters.rs
+++ b/heim-process/src/sys/windows/process/io_counters.rs
@@ -5,58 +5,43 @@ use winapi::um::winnt;
 /// For additional information, see [IO_COUNTERS] documentation.
 ///
 /// [IO_COUNTERS]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-io_counters
-#[derive(Default)]
-pub struct IoCounters {
-    read_operation_count: u64,
-    write_operation_count: u64,
-    other_operation_count: u64,
-    read_transfer_count: u64,
-    write_transfer_count: u64,
-    other_transfer_count: u64,
-}
+pub struct IoCounters(winnt::IO_COUNTERS);
 
 impl IoCounters {
     /// The number of read operations performed.
     pub fn read_iops(&self) -> u64 {
-        self.read_operation_count
+        self.0.ReadOperationCount
     }
 
     /// The number of read operations performed.
     pub fn write_iops(&self) -> u64 {
-        self.write_operation_count
+        self.0.WriteOperationCount
     }
 
     /// The number of I/O operations performed, other than read and write operations.
     pub fn other_iops(&self) -> u64 {
-        self.other_operation_count
+        self.0.OtherOperationCount
     }
 
     /// The number of bytes read.
     pub fn bytes_read(&self) -> Information {
-        Information::new::<information::byte>(self.read_transfer_count)
+        Information::new::<information::byte>(self.0.ReadTransferCount)
     }
 
     /// The number of bytes written.
     pub fn bytes_written(&self) -> Information {
-        Information::new::<information::byte>(self.write_transfer_count)
+        Information::new::<information::byte>(self.0.WriteTransferCount)
     }
 
     /// The number of bytes transferred during operations other than read and write operations.
     pub fn bytes_other(&self) -> Information {
-        Information::new::<information::byte>(self.other_transfer_count)
+        Information::new::<information::byte>(self.0.OtherTransferCount)
     }
 }
 
 impl From<winnt::IO_COUNTERS> for IoCounters {
     fn from(info: winnt::IO_COUNTERS) -> IoCounters {
-        IoCounters {
-            read_operation_count: info.ReadOperationCount,
-            write_operation_count: info.WriteOperationCount,
-            other_operation_count: info.OtherOperationCount,
-            read_transfer_count: info.ReadTransferCount,
-            write_transfer_count: info.WriteTransferCount,
-            other_transfer_count: info.OtherTransferCount,
-        }
+        IoCounters(info)
     }
 }
 

--- a/heim-process/src/sys/windows/process/io_counters.rs
+++ b/heim-process/src/sys/windows/process/io_counters.rs
@@ -1,0 +1,16 @@
+use heim_common::Pid;
+use std::fmt;
+use crate::ProcessResult;
+#[derive(Default)]
+pub struct IoCounters;
+
+
+pub async fn io(_pid: Pid) -> ProcessResult<IoCounters> {
+    ProcessResult::Ok(IoCounters)
+}
+
+impl fmt::Debug for IoCounters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("IoCounters").finish()
+    }
+}

--- a/heim-process/src/sys/windows/process/io_counters.rs
+++ b/heim-process/src/sys/windows/process/io_counters.rs
@@ -1,21 +1,21 @@
-use std::fmt;
 use heim_common::units::{information, Information};
+use std::fmt;
 use winapi::um::winnt;
 /// Process IO statistics.
 /// For additional information, see [IO_COUNTERS] documentation.
 ///
 /// [IO_COUNTERS]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-io_counters
 #[derive(Default)]
-pub struct IoCounters{
+pub struct IoCounters {
     read_operation_count: u64,
     write_operation_count: u64,
     other_operation_count: u64,
     read_transfer_count: u64,
     write_transfer_count: u64,
-    other_transfer_count: u64
+    other_transfer_count: u64,
 }
 
-impl IoCounters{
+impl IoCounters {
     /// The number of read operations performed.
     pub fn read_iops(&self) -> u64 {
         self.read_operation_count
@@ -47,29 +47,28 @@ impl IoCounters{
     }
 }
 
-impl From<winnt::IO_COUNTERS> for IoCounters{
-    fn from(info: winnt::IO_COUNTERS) -> IoCounters{
-        IoCounters{
+impl From<winnt::IO_COUNTERS> for IoCounters {
+    fn from(info: winnt::IO_COUNTERS) -> IoCounters {
+        IoCounters {
             read_operation_count: info.ReadOperationCount,
             write_operation_count: info.WriteOperationCount,
             other_operation_count: info.OtherOperationCount,
             read_transfer_count: info.ReadTransferCount,
             write_transfer_count: info.WriteTransferCount,
-            other_transfer_count: info.OtherTransferCount
+            other_transfer_count: info.OtherTransferCount,
         }
     }
 }
 
-
 impl fmt::Debug for IoCounters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("IoCounters")
-        .field("bytes_read", &self.bytes_read())
-        .field("bytes_written", &self.bytes_written())        
-        .field("bytes_other", &self.bytes_other())
-        .field("read_iops", &self.read_iops())        
-        .field("write_iops", &self.write_iops())
-        .field("other_iops", &self.other_iops())
-        .finish()
+            .field("bytes_read", &self.bytes_read())
+            .field("bytes_written", &self.bytes_written())
+            .field("bytes_other", &self.bytes_other())
+            .field("read_iops", &self.read_iops())
+            .field("write_iops", &self.write_iops())
+            .field("other_iops", &self.other_iops())
+            .finish()
     }
 }

--- a/heim-process/src/sys/windows/process/io_counters.rs
+++ b/heim-process/src/sys/windows/process/io_counters.rs
@@ -1,16 +1,75 @@
-use heim_common::Pid;
 use std::fmt;
-use crate::ProcessResult;
+use heim_common::units::{information, Information};
+use winapi::um::winnt;
+/// Process IO statistics.
+/// For additional information, see [IO_COUNTERS] documentation.
+///
+/// [IO_COUNTERS]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-io_counters
 #[derive(Default)]
-pub struct IoCounters;
-
-
-pub async fn io(_pid: Pid) -> ProcessResult<IoCounters> {
-    ProcessResult::Ok(IoCounters)
+pub struct IoCounters{
+    read_operation_count: u64,
+    write_operation_count: u64,
+    other_operation_count: u64,
+    read_transfer_count: u64,
+    write_transfer_count: u64,
+    other_transfer_count: u64
 }
+
+impl IoCounters{
+    /// The number of read operations performed.
+    pub fn read_iops(&self) -> u64 {
+        self.read_operation_count
+    }
+
+    /// The number of read operations performed.
+    pub fn write_iops(&self) -> u64 {
+        self.write_operation_count
+    }
+
+    /// The number of I/O operations performed, other than read and write operations.
+    pub fn other_iops(&self) -> u64 {
+        self.other_operation_count
+    }
+
+    /// The number of bytes read.
+    pub fn bytes_read(&self) -> Information {
+        Information::new::<information::byte>(self.read_transfer_count)
+    }
+
+    /// The number of bytes written.
+    pub fn bytes_written(&self) -> Information {
+        Information::new::<information::byte>(self.write_transfer_count)
+    }
+
+    /// The number of bytes transferred during operations other than read and write operations.
+    pub fn bytes_other(&self) -> Information {
+        Information::new::<information::byte>(self.other_transfer_count)
+    }
+}
+
+impl From<winnt::IO_COUNTERS> for IoCounters{
+    fn from(info: winnt::IO_COUNTERS) -> IoCounters{
+        IoCounters{
+            read_operation_count: info.ReadOperationCount,
+            write_operation_count: info.WriteOperationCount,
+            other_operation_count: info.OtherOperationCount,
+            read_transfer_count: info.ReadTransferCount,
+            write_transfer_count: info.WriteTransferCount,
+            other_transfer_count: info.OtherTransferCount
+        }
+    }
+}
+
 
 impl fmt::Debug for IoCounters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("IoCounters").finish()
+        f.debug_struct("IoCounters")
+        .field("bytes_read", &self.bytes_read())
+        .field("bytes_written", &self.bytes_written())        
+        .field("bytes_other", &self.bytes_other())
+        .field("read_iops", &self.read_iops())        
+        .field("write_iops", &self.write_iops())
+        .field("other_iops", &self.other_iops())
+        .finish()
     }
 }

--- a/heim-process/src/sys/windows/process/mod.rs
+++ b/heim-process/src/sys/windows/process/mod.rs
@@ -190,7 +190,15 @@ impl Process {
     }
 
     pub async fn io_counters(&self) -> ProcessResult<IoCounters> {
-        io_counters::io(self.pid).await
+        if self.pid == 0 || self.pid == 4 {
+            Err(ProcessError::AccessDenied(self.pid))
+        } else {
+            let handle = bindings::ProcessHandle::query_limited_info(self.pid)?;
+            match handle.io_counters(){
+                Ok(content) => ProcessResult::Ok(IoCounters::from(content)),
+                Err(e) => Err(e.into())
+            }
+        }
     }
 }
 

--- a/heim-process/src/sys/windows/process/mod.rs
+++ b/heim-process/src/sys/windows/process/mod.rs
@@ -17,16 +17,16 @@ mod command;
 mod cpu_times;
 mod create_time;
 mod env;
+mod io_counters;
 mod memory;
 mod priority;
 mod suspend;
-mod io_counters;
 
 pub use self::command::{Command, CommandIter};
 pub use self::cpu_times::CpuTime;
 pub use self::env::{Environment, EnvironmentIter, IntoEnvironmentIter};
-pub use self::memory::Memory;
 pub use self::io_counters::IoCounters;
+pub use self::memory::Memory;
 
 #[derive(Debug)]
 pub struct Process {
@@ -194,9 +194,9 @@ impl Process {
             Err(ProcessError::AccessDenied(self.pid))
         } else {
             let handle = bindings::ProcessHandle::query_limited_info(self.pid)?;
-            match handle.io_counters(){
+            match handle.io_counters() {
                 Ok(content) => ProcessResult::Ok(IoCounters::from(content)),
-                Err(e) => Err(e.into())
+                Err(e) => Err(e.into()),
             }
         }
     }

--- a/heim-process/src/sys/windows/process/mod.rs
+++ b/heim-process/src/sys/windows/process/mod.rs
@@ -196,7 +196,7 @@ impl Process {
             let handle = bindings::ProcessHandle::query_limited_info(self.pid)?;
             match handle.io_counters() {
                 Ok(content) => ProcessResult::Ok(IoCounters::from(content)),
-                Err(e) => Err(e.into()),
+                Err(e) => Err(e),
             }
         }
     }

--- a/heim-process/src/sys/windows/process/mod.rs
+++ b/heim-process/src/sys/windows/process/mod.rs
@@ -20,11 +20,13 @@ mod env;
 mod memory;
 mod priority;
 mod suspend;
+mod io_counters;
 
 pub use self::command::{Command, CommandIter};
 pub use self::cpu_times::CpuTime;
 pub use self::env::{Environment, EnvironmentIter, IntoEnvironmentIter};
 pub use self::memory::Memory;
+pub use self::io_counters::IoCounters;
 
 #[derive(Debug)]
 pub struct Process {
@@ -185,6 +187,10 @@ impl Process {
 
     pub async fn wait(&self) -> ProcessResult<()> {
         unimplemented!()
+    }
+
+    pub async fn io_counters(&self) -> ProcessResult<IoCounters> {
+        io_counters::io(self.pid).await
     }
 }
 

--- a/heim-process/tests/smoke.rs
+++ b/heim-process/tests/smoke.rs
@@ -67,6 +67,7 @@ async fn smoke_processes() -> Result<()> {
         try_method!(process.cpu_usage());
         try_method!(process.memory());
         try_method!(process.is_running());
+        try_method!(process.io_counters());
 
         #[cfg(unix)]
         {
@@ -79,7 +80,6 @@ async fn smoke_processes() -> Result<()> {
         {
             use heim_process::os::linux::ProcessExt;
 
-            try_method!(process.io_counters());
             try_method!(process.net_io_counters());
         }
 


### PR DESCRIPTION
This pull request adds IO Process Counters for Windows and MacOS. 

The two common fields are part of have methods on the common `IoCounters` struct.