### PR TITLE
Fix macos process kinfo

### DIFF
--- a/heim-process/src/sys/macos/bindings/process.rs
+++ b/heim-process/src/sys/macos/bindings/process.rs
@@ -7,7 +7,6 @@ use mach::{boolean, vm_types};
 
 use heim_common::prelude::Error;
 
-use crate::sys::unix::bindings::errno;
 use crate::{Pid, ProcessError, Status};
 
 // Process status values, declared at `bsd/sys/proc.h`
@@ -214,7 +213,7 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
             // `libc::ENOMEM` indicates there was not enough space in `processes` to store the whole
             // process list which can occur when a new process spawns between getting the size and
             // storing. If this is the case then simply try again.
-            if errno() == libc::ENOMEM {
+            if io::Error::last_os_error().raw_os_error().unwrap() == libc::ENOMEM {
                 continue;
             } else {
                 return Err(Error::last_os_error().with_sysctl(name.as_ref()));

--- a/heim-process/src/sys/macos/bindings/process.rs
+++ b/heim-process/src/sys/macos/bindings/process.rs
@@ -213,10 +213,11 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
             // `libc::ENOMEM` indicates there was not enough space in `processes` to store the whole
             // process list which can occur when a new process spawns between getting the size and
             // storing. If this is the case then simply try again.
-            if io::Error::last_os_error().raw_os_error().unwrap() == libc::ENOMEM {
+            let err = Error::last_os_error();
+            if let Some(libc::ENOMEM) = err.raw_os_error() {
                 continue;
             } else {
-                return Err(Error::last_os_error().with_sysctl(name.as_ref()));
+                return Err(err.with_sysctl(name.as_ref()));
             }
         } else {
             // Getting the list succeeded so let `processes` know how many processes it holds

--- a/heim-process/src/sys/macos/bindings/process.rs
+++ b/heim-process/src/sys/macos/bindings/process.rs
@@ -217,7 +217,7 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
             if errno() == libc::ENOMEM {
                 continue;
             } else {
-                return Err(io::Error::last_os_error().with_sysctl(name.as_ref()));
+                return Err(Error::last_os_error().with_sysctl(name.as_ref()));
             }
         } else {
             // Getting the list succeeded so let `processes` know how many processes it holds

--- a/heim-process/src/sys/macos/bindings/process.rs
+++ b/heim-process/src/sys/macos/bindings/process.rs
@@ -176,6 +176,7 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
     let mut processes: Vec<kinfo_proc> = vec![];
 
     loop {
+        // Dry-run to get the size required for the process list
         let result = unsafe {
             libc::sysctl(
                 name.as_mut_ptr(),
@@ -196,6 +197,7 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
             processes.reserve_exact(num_processes - processes.capacity());
         }
 
+        // Attempt to store the process list in `processes`
         let result = unsafe {
             libc::sysctl(
                 name.as_mut_ptr(),

--- a/heim-process/src/sys/macos/bindings/process.rs
+++ b/heim-process/src/sys/macos/bindings/process.rs
@@ -190,7 +190,11 @@ pub fn processes() -> Result<Vec<kinfo_proc>, Error> {
             return Err(Error::last_os_error().with_sysctl(name.as_ref()));
         }
 
-        processes.reserve(size);
+        // Reserve enough room to store the whole process list
+        let num_processes = size / mem::size_of::<kinfo_proc>();
+        if num_processes > processes.capacity() {
+            processes.reserve_exact(num_processes - processes.capacity());
+        }
 
         let result = unsafe {
             libc::sysctl(


### PR DESCRIPTION
*copy-pasting from rust-psutil/rust-psutil#80 with some small tweaks*

In cjbassi/ytop#75 some users, specifically on MacOS, were running into issues where `OsError { source: Os { code: 12, kind: Other, message: "Cannot allocate memory" } }` was being returned when trying to update the process list.

I eventually tracked this down to `processes()` that had a couple of issues leading to this problem:

1. `reserve` will reserve an additional number of elements represented by the value passed in whereas here it was being given the expected size of all elements in bytes. This was resulting in much more space being reserved than was required.
2. Incorrectly checking for `ENOMEM`. Based on [this](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html) document:

> If the amount of data available is greater than the size of the buffer supplied, the call supplies as much data as fits in the buffer provided and returns with the error code `ENOMEM`.

However

> Upon successful completion, the value 0 is returned; otherwise the value -1 is returned and the global variable `errno` is set to indicate the error.

So I can understand the confusion from the wording, but when it mentions returning `ENOMEM` this is in the form of `errno`, not as the return value from the function call. This manifested where the code would check for `ENOMEM` from `sysctl` instead of `errno`, which would cause the error to bubble up instead of appropriately retrying. I think the large reserve size made this case easier to hit since it would stall for more time between reading for the required size and attempting to store.

I would appreciate a thorough look over the changes since it's pretty close to messing with `unsafe` code and I was able to reproduce the issue on MacOS, but didn't have a chance to verify that the changes work correctly.