### PR TITLE
Win32 cwd

### DIFF
--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -49,7 +49,9 @@ features = [
     "psapi",
     "processthreadsapi",
     "winerror",
-    "tlhelp32"
+    "tlhelp32",
+    "wow64apiset",
+    "memoryapi",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/heim-process/src/errors.rs
+++ b/heim-process/src/errors.rs
@@ -22,6 +22,8 @@ pub enum ProcessError {
     AccessDenied(Pid),
     /// Data loading failure.
     Load(Error),
+    /// UnreadablePeb
+    UnreadablePeb(Pid),
 }
 
 impl fmt::Display for ProcessError {
@@ -35,6 +37,9 @@ impl fmt::Display for ProcessError {
             }
             ProcessError::AccessDenied(pid) => {
                 f.write_fmt(format_args!("Access denied for process {}", pid))
+            }
+            ProcessError::UnreadablePeb(pid) => {
+                f.write_fmt(format_args!("Unable to read process PEB {}", pid))
             }
             ProcessError::Load(e) => fmt::Display::fmt(e, f),
         }

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -230,7 +230,7 @@ impl ProcessHandle<QueryLimitedInformation> {
         if status == ntstatus::STATUS_SUCCESS {
             unsafe { Ok(pbi.assume_init()) }
         } else {
-            Err(Error::last_os_error()
+            Err(Error::from_raw_os_error(status | winerror::FACILITY_NT_BIT)
                 .with_ffi("NtQueryInformationProcess")
                 .into())
         }
@@ -251,7 +251,7 @@ impl ProcessHandle<QueryLimitedInformation> {
         };
 
         if ret != ntstatus::STATUS_SUCCESS {
-            return Err(Error::last_os_error()
+            return Err(Error::from_raw_os_error(ret | winerror::FACILITY_NT_BIT)
                 .with_ffi("NtQueryInformationProcess")
                 .into());
         }

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -14,7 +14,7 @@ use std::ptr;
 use ntapi::{ntpebteb, ntpsapi, ntrtl, ntwow64};
 use winapi::ctypes::wchar_t;
 use winapi::shared::minwindef::{DWORD, FILETIME, MAX_PATH};
-use winapi::shared::{ntstatus, winerror};
+use winapi::shared::{basetsd, ntstatus, winerror};
 use winapi::um::{memoryapi, processthreadsapi, psapi, winbase, winnt, wow64apiset};
 
 use heim_common::sys::IntoTime;
@@ -237,7 +237,7 @@ impl ProcessHandle<QueryLimitedInformation> {
     }
 
     fn get_peb32(&self) -> ProcessResult<Option<ntwow64::PEB32>> {
-        let mut peb32_remote_addr: *mut ntwow64::PEB32 = ptr::null_mut();
+        let mut peb32_remote_addr: basetsd::ULONG_PTR = 0;
 
         #[allow(trivial_casts)] // wtf rust.
         let ret = unsafe {
@@ -245,7 +245,7 @@ impl ProcessHandle<QueryLimitedInformation> {
                 *self.handle,
                 ntpsapi::ProcessWow64Information,
                 &mut peb32_remote_addr as *mut _ as _,
-                mem::size_of::<ntwow64::PEB32>() as _,
+                mem::size_of::<basetsd::ULONG_PTR>() as _,
                 ptr::null_mut(),
             )
         };
@@ -256,7 +256,7 @@ impl ProcessHandle<QueryLimitedInformation> {
                 .into());
         }
 
-        if peb32_remote_addr.is_null() {
+        if peb32_remote_addr == 0 {
             return Ok(None);
         }
 

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -231,7 +231,7 @@ impl ProcessHandle<QueryLimitedInformation> {
             unsafe { Ok(pbi.assume_init()) }
         } else {
             Err(Error::from_raw_os_error(status | winerror::FACILITY_NT_BIT)
-                .with_ffi("NtQueryInformationProcess")
+                .with_ffi("NtQueryInformationProcessBasicInfo")
                 .into())
         }
     }
@@ -252,7 +252,7 @@ impl ProcessHandle<QueryLimitedInformation> {
 
         if ret != ntstatus::STATUS_SUCCESS {
             return Err(Error::from_raw_os_error(ret | winerror::FACILITY_NT_BIT)
-                .with_ffi("NtQueryInformationProcess")
+                .with_ffi("NtQueryInformationProcessPeb32")
                 .into());
         }
 

--- a/heim-process/src/sys/windows/bindings/handle/limited_info.rs
+++ b/heim-process/src/sys/windows/bindings/handle/limited_info.rs
@@ -357,7 +357,7 @@ impl ProcessHandle<QueryLimitedInformation> {
             return Err(ProcessError::UnreadablePeb(self.pid));
         };
 
-        let mut buf = vec![0u16; len as usize / 2 + 2];
+        let mut buf = vec![0u16; len as usize / 2];
 
         unsafe {
             self.read_memory(src, buf.as_mut_ptr() as _, len as _)?;

--- a/heim-process/src/sys/windows/process/mod.rs
+++ b/heim-process/src/sys/windows/process/mod.rs
@@ -105,7 +105,9 @@ impl Process {
     }
 
     pub async fn cwd(&self) -> ProcessResult<PathBuf> {
-        unimplemented!("https://github.com/heim-rs/heim/issues/105")
+        let handle = bindings::ProcessHandle::query_limited_info(self.pid)?;
+
+        handle.cwd()
     }
 
     pub async fn status(&self) -> ProcessResult<Status> {

--- a/heim-process/tests/smoke.rs
+++ b/heim-process/tests/smoke.rs
@@ -57,7 +57,6 @@ async fn smoke_processes() -> Result<()> {
         try_method!(process.name());
         try_method!(process.command());
         try_method!(process.exe());
-        #[cfg(not(target_os = "windows"))] // Not implemented yet
         try_method!(process.cwd());
         try_method!(process.status());
         #[cfg(any(target_os = "linux", target_os = "macos"))] // Not implemented yet for all platforms


### PR DESCRIPTION
Here's my first attempt at implementing cwd for window, mostly based on the code of PSUtil.

Fixes #105 

It works by parsing the PEB data structure found in each process. This data structure, along with the APIs used to acquire it, are unstable and, according to microsoft, the APIs may change. In practice, a significant amount of software is built on top of this API, and as such it is unlikely to be broken. If it does break, I expect microsoft to provide a stable API to acquire this information, like they did for the CommandLine.

I tested this with various combination on intel (x86 and x64) CPUs:

- Host: 32-bit, Heim: 32-bit, Target: 32-bit
- Host: 64-bit, Heim: 64-bit, Target: 64-bit
- Host: 64-bit, Heim: 64-bit, Target: 32-bit
- Host: 64-bit, Heim: 32-bit, Target: 32-bit

I did not implement this under ARM, as it requires using a fairly new API. We'd need to do a runtime check to see if the API is present, I'm not sure what the best way to do this is.
Furthermore, getting a 64-bit process' CWD from a 32-bit Heim is not implemented, as it requires relying on even more unstable APIs, and I don't personally need it.