### PR TITLE
Version-sync should be a build dependency

### DIFF
--- a/heim-runtime/Cargo.toml
+++ b/heim-runtime/Cargo.toml
@@ -13,6 +13,8 @@ license = "Apache-2.0 OR MIT"
 futures = { version = "~0.3", default-features = false, features = ["std"] }
 futures-timer = "~3.0"
 smol = "~0.1"
+
+[build-dependencies]
 version-sync = "0.9"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
That dependency is only used in unit tests. Having it as a dependency slows library users build time by compiling unused code.