### PR TITLE
Make CpuTime/CpuUsage clone-able

### DIFF
--- a/heim-cpu/src/sys/linux/times.rs
+++ b/heim-cpu/src/sys/linux/times.rs
@@ -5,7 +5,7 @@ use heim_common::sys::unix::CLOCK_TICKS;
 use heim_common::units::{time, Time};
 use heim_runtime as rt;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct CpuTime {
     user: Time,
     nice: Time,

--- a/heim-cpu/src/sys/macos/times.rs
+++ b/heim-cpu/src/sys/macos/times.rs
@@ -4,7 +4,7 @@ use heim_common::units::{time, Time};
 
 use super::bindings;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     user: Time,
     nice: Time,

--- a/heim-cpu/src/sys/windows/times.rs
+++ b/heim-cpu/src/sys/windows/times.rs
@@ -6,7 +6,7 @@ use heim_common::prelude::*;
 use heim_common::sys::IntoTime as _;
 use heim_common::units::Time;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     user: Time,
     system: Time,

--- a/heim-cpu/src/times.rs
+++ b/heim-cpu/src/times.rs
@@ -12,6 +12,7 @@ use crate::sys;
 /// For Linux additional information can be retrieved with [CpuTimeExt] extension trait.
 ///
 /// [CpuTimeExt]: ./os/linux/trait.CpuTimeExt.html
+#[derive(Clone)]
 pub struct CpuTime(sys::CpuTime);
 
 wrap!(CpuTime, sys::CpuTime);

--- a/heim-process/src/process/cpu_times.rs
+++ b/heim-process/src/process/cpu_times.rs
@@ -6,6 +6,7 @@ use heim_common::units::Time;
 use crate::sys;
 
 /// Accumulated CPU time for specific process.
+#[derive(Clone)]
 pub struct CpuTime(sys::CpuTime);
 
 wrap!(CpuTime, sys::CpuTime);

--- a/heim-process/src/process/cpu_usage.rs
+++ b/heim-process/src/process/cpu_usage.rs
@@ -8,7 +8,7 @@ use super::CpuTime;
 /// Process CPU usage measurement.
 ///
 /// See [Process::cpu_usage](./struct.Process.html#method.cpu_usage) method for details.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuUsage {
     pub(crate) cpu_count: u64,
     pub(crate) cpu_time: CpuTime,

--- a/heim-process/src/sys/linux/process/procfs/cpu_times.rs
+++ b/heim-process/src/sys/linux/process/procfs/cpu_times.rs
@@ -2,7 +2,7 @@ use heim_common::units::Time;
 
 use super::Stat;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     utime: Time,
     stime: Time,

--- a/heim-process/src/sys/macos/process/cpu_times.rs
+++ b/heim-process/src/sys/macos/process/cpu_times.rs
@@ -1,6 +1,6 @@
 use heim_common::units::{time, Time};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     utime: Time,
     stime: Time,

--- a/heim-process/src/sys/windows/process/cpu_times.rs
+++ b/heim-process/src/sys/windows/process/cpu_times.rs
@@ -1,6 +1,6 @@
 use heim_common::units::Time;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     pub(crate) user: Time,
     pub(crate) kernel: Time,


### PR DESCRIPTION
There doesn't appear to be any reason to prevent CpuTime and CpuUsage structures to be cloneable, and it allows reusing previous process::usage() result to continuously calculate the cpu usage.