### PR TITLE
Detect PowerPC64 when uname says 'ppc64le' or 'ppc64'

### DIFF
--- a/heim-host/src/sys/unix/platform.rs
+++ b/heim-host/src/sys/unix/platform.rs
@@ -82,6 +82,7 @@ fn arch_from_uname(raw: &str) -> Option<Arch> {
 
     match raw {
         "armv7" | "armv7l" => Some(Arch::ARM),
+        "ppc64" | "ppc64le" => Some(Arch::POWERPC64),
         _ => None,
     }
 }


### PR DESCRIPTION
To add support for PowerPC 64 CPU detection