### PR TITLE
Bump ordered-float to v1.1.1 in v0.0.x due to potential UB

### DIFF
--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -21,7 +21,7 @@ heim-cpu = { version = "0.0.11", path = "../heim-cpu" }
 cfg-if = "0.1.7"
 libc = "~0.2"
 lazy_static = "1.3.0"
-ordered-float = { version = "~1.0", default-features = false }
+ordered-float = { version = "~1.1", default-features = false }
 memchr = "~2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
As per [RUSTSEC-2020-0082](https://github.com/RustSec/advisory-db/blob/dec05d79abc4e468cc225e36af6351d19e7b8063/crates/ordered-float/RUSTSEC-2020-0082.md), version 1.1.1 of the `ordered-float` dependency fixes a potential cause of UB.

This doesn't appear to affect the master branch, but it does affect v0.0.x versions.