### PR TITLE
Replace `Duration::as_secs` by `Duration::as_secs_f64`

### DIFF
--- a/heim-cpu/src/usage.rs
+++ b/heim-cpu/src/usage.rs
@@ -25,11 +25,7 @@ impl ops::Sub<CpuUsage> for CpuUsage {
             + (self.cpu_time.system() - rhs.cpu_time.system());
         let delta_time = self.at - rhs.at;
 
-        // TODO: Can be replaced with a `delta_time.as_secs_f64()`
-        // as soon as https://github.com/rust-lang/rust/issues/54361 will be stable
-        const NANOS_PER_SEC: u32 = 1_000_000_000;
-        let mut delta_time_secs =
-            (delta_time.as_secs() as f64) + (delta_time.as_nanos() as f64) / (NANOS_PER_SEC as f64);
+        let mut delta_time_secs = delta_time.as_secs_f64();
 
         // Time should calculated across all the cores available
         delta_time_secs *= self.cpu_count as f64;

--- a/heim-process/src/process/cpu_usage.rs
+++ b/heim-process/src/process/cpu_usage.rs
@@ -24,11 +24,7 @@ impl ops::Sub<CpuUsage> for CpuUsage {
             + (self.cpu_time.system() - rhs.cpu_time.system());
         let delta_time = self.at - rhs.at;
 
-        // TODO: Can be replaced with a `delta_time.as_secs_f64()`
-        // as soon as https://github.com/rust-lang/rust/issues/54361 will be stable
-        const NANOS_PER_SEC: u32 = 1_000_000_000;
-        let mut delta_time_secs =
-            (delta_time.as_secs() as f64) + (delta_time.as_nanos() as f64) / (NANOS_PER_SEC as f64);
+        let mut delta_time_secs = delta_time.as_secs_f64();
 
         // Time should calculated across all the cores available
         delta_time_secs *= self.cpu_count as f64;


### PR DESCRIPTION
Hi!
This commit just replace the cast to `f64` with the appropriate function.
Closes #296.