### PR TITLE
fix swap file calculation on windows

### DIFF
--- a/heim-memory/src/sys/windows/mod.rs
+++ b/heim-memory/src/sys/windows/mod.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 /// https://docs.microsoft.com/en-US/windows/desktop/api/sysinfoapi/ns-sysinfoapi-_memorystatusex
 use std::fmt;
 use std::mem;
@@ -40,7 +41,7 @@ pub struct Swap(sysinfoapi::MEMORYSTATUSEX);
 
 impl Swap {
     pub fn total(&self) -> Information {
-        Information::new::<information::byte>(self.0.ullTotalPageFile)
+        Information::new::<information::byte>(self.0.ullTotalPageFile - self.0.ullTotalPhys)
     }
 
     pub fn used(&self) -> Information {
@@ -48,7 +49,10 @@ impl Swap {
     }
 
     pub fn free(&self) -> Information {
-        Information::new::<information::byte>(self.0.ullAvailPageFile)
+        cmp::min(
+            Information::new::<information::byte>(self.0.ullAvailPageFile - self.0.ullAvailPhys),
+            self.total(),
+        )
     }
 }
 


### PR DESCRIPTION
`ullTotalPageFile` and `ullAvailPageFile` include both the swap and physical memory so in order to get the correct swap memory values the physical memory size/usage needs to be subtracted.

https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex