### PR TITLE
Make heim::nic Send+Sync

### DIFF
--- a/heim-net/src/nic.rs
+++ b/heim-net/src/nic.rs
@@ -88,7 +88,7 @@ impl fmt::Debug for Nic {
 /// Returns a stream over the [Network Interface Cards].
 ///
 /// [Network Interface Cards]: struct.Nic.html
-pub async fn nic() -> Result<impl Stream<Item = Result<Nic>>> {
+pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
     let inner = sys::nic().await?;
 
     Ok(inner.map_ok(Into::into))

--- a/heim-net/src/sys/unix/nic.rs
+++ b/heim-net/src/sys/unix/nic.rs
@@ -62,14 +62,16 @@ impl Nic {
     }
 }
 
-pub async fn nic() -> Result<impl Stream<Item = Result<Nic>>> {
-    let iter = ifaddrs::getifaddrs()?.filter_map(|addr| {
-        if addr.address.is_some() {
-            Some(Ok(Nic(addr)))
-        } else {
-            None
-        }
-    });
+pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
+    let iter = ifaddrs::getifaddrs()?
+        .filter_map(|addr| {
+            if addr.address.is_some() {
+                Some(Ok(Nic(addr)))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
 
     Ok(stream::iter(iter))
 }

--- a/heim-net/src/sys/windows/nic.rs
+++ b/heim-net/src/sys/windows/nic.rs
@@ -51,7 +51,7 @@ impl Nic {
     }
 }
 
-pub async fn nic() -> Result<impl Stream<Item = Result<Nic>>> {
+pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
     // TODO: Stub
     Ok(stream::empty())
 }


### PR DESCRIPTION
This makes it much easier to use it with runtimes that expect the ability to move futures between threads (like tokio).