### PR TITLE
Added FAT file system so that FAT formatted disks are recognized

### DIFF
--- a/heim-disk/src/filesystem.rs
+++ b/heim-disk/src/filesystem.rs
@@ -24,6 +24,9 @@ pub enum FileSystem {
     /// exFAT (https://en.wikipedia.org/wiki/ExFAT)
     ExFat,
 
+    /// FAT (https://en.wikipedia.org/wiki/File_Allocation_Table)
+    Fat,
+
     /// F2FS (https://en.wikipedia.org/wiki/F2FS)
     F2fs,
 
@@ -110,6 +113,7 @@ impl FileSystem {
             FileSystem::Nilfs => "nilfs",
             FileSystem::Xfs => "xfs",
             FileSystem::Apfs => "apfs",
+            FileSystem::Fat => "fat",
             FileSystem::Other(string) => string.as_str(),
         }
     }
@@ -138,6 +142,7 @@ impl FromStr for FileSystem {
             _ if s.eq_ignore_ascii_case("nilfs") => Ok(FileSystem::Nilfs),
             _ if s.eq_ignore_ascii_case("xfs") => Ok(FileSystem::Xfs),
             _ if s.eq_ignore_ascii_case("apfs") => Ok(FileSystem::Apfs),
+            _ if s.eq_ignore_ascii_case("msdos") => Ok(FileSystem::Fat),
 
             _ if s.eq_ignore_ascii_case("fuseblk") => Ok(FileSystem::FuseBlk),
             _ => Ok(FileSystem::Other(s.to_string())),


### PR DESCRIPTION
On MacOS, external disks that are formatted with FAT16/FAT32 (yes, I still have some!) are filtered (`is_physical`) from the list of file systems because the file system name is 'msdos', which isn't in the `FileSystem` enum.

Before the change:
```
Partition { device: Some("/dev/disk1s1"), mount_point: "/", file_system: Apfs }
Partition { device: Some("/dev/disk1s4"), mount_point: "/private/var/vm", file_system: Apfs }
```

After the change:
```
Partition { device: Some("/dev/disk1s1"), mount_point: "/", file_system: Apfs }
Partition { device: Some("/dev/disk1s4"), mount_point: "/private/var/vm", file_system: Apfs }
Partition { device: Some("/dev/disk2s1"), mount_point: "/Volumes/NO NAME", file_system: Fat }
```

Though the result from `statfs` is `msdos` I made the enum value `Fat`. Let me know if you'd like something different or to use the existing `VFat`