### PR TITLE
Fix a possible segfault in heim::net::nic() for Windows

### DIFF
--- a/heim-cpu/src/sys/linux/freq.rs
+++ b/heim-cpu/src/sys/linux/freq.rs
@@ -46,7 +46,7 @@ impl ops::Add<CpuFrequency> for CpuFrequency {
             (None, None) => None,
         };
 
-        CpuFrequency { current, max, min }
+        CpuFrequency { current, min, max }
     }
 }
 
@@ -69,7 +69,7 @@ fn _frequencies() -> impl Iterator<Item = Result<CpuFrequency>> {
         let max = max_freq(&path);
         let min = min_freq(&path);
 
-        Ok(CpuFrequency { current, max, min })
+        Ok(CpuFrequency { current, min, max })
     })
 }
 

--- a/heim-disk/src/sys/linux/counters.rs
+++ b/heim-disk/src/sys/linux/counters.rs
@@ -104,12 +104,12 @@ impl FromStr for IoCounters {
         Ok(IoCounters {
             name,
             read_count,
-            read_merged_count,
-            read_bytes,
             write_count,
-            write_merged_count,
+            read_bytes,
             write_bytes,
             busy_time,
+            read_merged_count,
+            write_merged_count,
         })
     }
 }

--- a/heim-memory/src/sys/macos/memory.rs
+++ b/heim-memory/src/sys/macos/memory.rs
@@ -68,8 +68,8 @@ pub async fn memory() -> Result<Memory> {
     Ok(Memory {
         total,
         available,
-        free,
         used,
+        free,
         active,
         inactive,
         wire,

--- a/heim-memory/src/sys/macos/swap.rs
+++ b/heim-memory/src/sys/macos/swap.rs
@@ -48,8 +48,8 @@ pub async fn swap() -> Result<Swap> {
 
     Ok(Swap {
         total,
-        free,
         used,
+        free,
         sin,
         sout,
     })

--- a/heim-net/src/sys/windows/nic.rs
+++ b/heim-net/src/sys/windows/nic.rs
@@ -192,12 +192,8 @@ pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
     // Step 3 - walk through the list and populate our interfaces
     let mut p_next_iface = buffer.as_ptr() as PIP_ADAPTER_ADDRESSES;
 
-    let mut cur_iface;
-    loop {
-        if p_next_iface.is_null() {
-            break;
-        }
-        cur_iface = unsafe { *p_next_iface };
+    while !p_next_iface.is_null() {
+        let cur_iface = unsafe { *p_next_iface };
 
         let iface_index = unsafe { cur_iface.u.s().IfIndex };
         let iface_guid_cstr;
@@ -233,12 +229,9 @@ pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
 
         // Walk through every IP address of this interface
         let mut p_next_address = cur_iface.FirstUnicastAddress;
-        let mut cur_address;
-        loop {
-            if p_next_address.is_null() {
-                break;
-            }
-            cur_address = unsafe { *p_next_address };
+
+        while !p_next_address.is_null() {
+            let cur_address = unsafe { *p_next_address };
 
             let this_socket_address = cur_address.Address;
             let this_netmask_length = cur_address.OnLinkPrefixLength;

--- a/heim-net/src/sys/windows/nic.rs
+++ b/heim-net/src/sys/windows/nic.rs
@@ -191,12 +191,6 @@ pub async fn nic() -> Result<impl Stream<Item = Result<Nic>> + Send + Sync> {
 
     // Step 3 - walk through the list and populate our interfaces
     let mut p_next_iface = buffer.as_ptr() as PIP_ADAPTER_ADDRESSES;
-    if p_next_iface.is_null() {
-        // Unable to list interfaces
-        let e = Error::from(std::io::Error::from_raw_os_error(res as _))
-            .with_ffi("GetAdaptersAddresses");
-        return Err(e);
-    }
 
     let mut cur_iface;
     loop {

--- a/heim-process/src/sys/unix/env.rs
+++ b/heim-process/src/sys/unix/env.rs
@@ -93,10 +93,7 @@ impl<'e> Iterator for EnvironmentIter<'e> {
     type Item = (&'e OsStr, &'e OsStr);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.0.next() {
-            Some((k, v)) => Some((k.as_os_str(), v.as_os_str())),
-            None => None,
-        }
+        self.0.next().map(|(k, v)| (k.as_os_str(), v.as_os_str()))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
Hello,

After some time using `heim::net::nic()` on Windows (which I implemented some time ago in ad691385940babcab857b1e19ebe95af35b8d70e), I realized I introduced a potential null pointer dereferencing :fearful: 

I've actually ran into this in some tests of mine, that segfaulted when an adapter had not been assigned any IP address.

This MR fixes this issue by properly checking for null pointers where I had forgotten to do so.
Luckily, this bug has never reached a tagged version nor a published version of the `heim` crate in `crates.io`