### PR TITLE
Use correct unit when parsing memory and swap from Linux

### DIFF
--- a/heim-memory/src/sys/linux/memory.rs
+++ b/heim-memory/src/sys/linux/memory.rs
@@ -79,7 +79,7 @@ impl FromStr for Memory {
                         let bytes = match value.trim_start().splitn(2, ' ').next() {
                             Some(kbytes) => {
                                 let value = kbytes.parse::<u64>()?;
-                                Information::new::<information::kilobyte>(value)
+                                Information::new::<information::kibibyte>(value)
                             }
                             None => continue,
                         };

--- a/heim-memory/src/sys/linux/swap.rs
+++ b/heim-memory/src/sys/linux/swap.rs
@@ -112,7 +112,7 @@ impl Swap {
                         let bytes = match value.trim_start().splitn(2, ' ').next() {
                             Some(kbytes) => {
                                 let value = kbytes.parse::<u64>()?;
-                                Information::new::<information::kilobyte>(value)
+                                Information::new::<information::kibibyte>(value)
                             }
                             None => continue,
                         };


### PR DESCRIPTION
Switch to treating parsed values from `/proc/meminfo` as kibibytes. Previously, it was treated as *kilobytes*, but apparently that's not correct, as per [this Red Hat doc](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo):

> While the file shows kilobytes (kB; 1 kB equals 1000 B), it is actually kibibytes (KiB; 1 KiB equals 1024 B). This imprecision in /proc/meminfo is known, but is not corrected due to legacy concerns - programs rely on /proc/meminfo to specify size with the "kB" string. 


---

Fixes: #341

