### PR TITLE
Fix process cpu time computation for macOS of M1 processor

### DIFF
--- a/heim-host/src/lib.rs
+++ b/heim-host/src/lib.rs
@@ -42,6 +42,8 @@ pub use self::boot_time::*;
 pub use self::platform::*;
 pub use self::uptime::*;
 pub use self::users::*;
+#[cfg(target_os = "macos")]
+pub use self::sys::TIME_BASE;
 
 pub use heim_common::units::Time;
 pub use heim_common::Pid;

--- a/heim-host/src/sys/macos/mod.rs
+++ b/heim-host/src/sys/macos/mod.rs
@@ -23,6 +23,7 @@ fn timebase_info() -> Result<mach_time::mach_timebase_info> {
 }
 
 lazy_static::lazy_static! {
+    /// Fraction to multiply a value in mach tick units with to convert it to nanoseconds.
     // Calling `mach_timebase_info` is not cheap, so we should cache it.
     // https://github.com/joyent/libuv/pull/1325
     pub static ref TIME_BASE: f64 = {

--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -18,6 +18,7 @@ github-actions = { repository = "heim-rs/heim", workflow = "Tier 1 CI" }
 heim-common = { version = "0.1.0-rc.1", path = "../heim-common" }
 heim-runtime = { version = "0.1.0-rc.1", path = "../heim-runtime" }
 heim-cpu = { version = "0.1.0-rc.1", path = "../heim-cpu" }
+heim-host = { version = "0.1.0-rc.1", path = "../heim-host" }
 cfg-if = "^1.0"
 libc = "^0.2"
 lazy_static = "1.3.0"

--- a/heim-process/src/sys/macos/process/cpu_times.rs
+++ b/heim-process/src/sys/macos/process/cpu_times.rs
@@ -1,4 +1,5 @@
 use heim_common::units::{time, Time};
+use heim_host::TIME_BASE;
 
 #[derive(Debug, Clone)]
 pub struct CpuTime {
@@ -19,8 +20,8 @@ impl CpuTime {
 impl From<darwin_libproc::proc_taskinfo> for CpuTime {
     fn from(info: darwin_libproc::proc_taskinfo) -> CpuTime {
         CpuTime {
-            utime: Time::new::<time::nanosecond>(info.pti_total_user as f64),
-            stime: Time::new::<time::nanosecond>(info.pti_total_system as f64),
+            utime: Time::new::<time::nanosecond>(info.pti_total_user as f64 * *TIME_BASE),
+            stime: Time::new::<time::nanosecond>(info.pti_total_system as f64 * *TIME_BASE),
         }
     }
 }


### PR DESCRIPTION
The numerator and denominator of `mach_timebase_info` won’t be the same on Apple Silicon Macs.

Apps should also build with `aarch64-apple-darwin` target.