### PR TITLE
Package upgrades

### DIFF
--- a/heim-host/Cargo.toml
+++ b/heim-host/Cargo.toml
@@ -16,7 +16,7 @@ log = "^0.4"
 heim-common = { version = "0.1.0-rc.1", path = "../heim-common" }
 heim-runtime = { version = "0.1.0-rc.1", path = "../heim-runtime" }
 cfg-if = "^1.0"
-platforms = "^1.1"
+platforms = "^2.0"
 libc = "^0.2"
 
 [dev-dependencies]

--- a/heim-host/src/sys/unix/platform.rs
+++ b/heim-host/src/sys/unix/platform.rs
@@ -81,8 +81,8 @@ fn arch_from_uname(raw: &str) -> Option<Arch> {
     };
 
     match raw {
-        "armv7" | "armv7l" | "arm64" => Some(Arch::ARM),
-        "ppc64" | "ppc64le" => Some(Arch::POWERPC64),
+        "armv7" | "armv7l" | "arm64" => Some(Arch::Arm),
+        "ppc64" | "ppc64le" => Some(Arch::PowerPc64),
         _ => None,
     }
 }

--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "^1.0"
 libc = "^0.2"
 lazy_static = "1.3.0"
 ordered-float = { version = "^2.1", default-features = false }
-memchr = "^2.2"
+memchr = "^2.4"
 async-trait = "^0.1"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Some package upgrades to make Heim easier to use with other dependencies.

This depends on https://github.com/heim-rs/darwin-libproc/pull/5 to compile correctly I believe. 