### PR TITLE
Update nix to 0.23

### DIFF
--- a/heim-common/Cargo.toml
+++ b/heim-common/Cargo.toml
@@ -20,7 +20,7 @@ uom = { version = "0.31.1", default-features = false, features = ["autoconvert",
 backtrace = { version = "^0.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.22"
+nix = "^0.23"
 lazy_static = "1.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/heim-common/Cargo.toml
+++ b/heim-common/Cargo.toml
@@ -20,7 +20,7 @@ uom = { version = "0.31.1", default-features = false, features = ["autoconvert",
 backtrace = { version = "^0.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.20"
+nix = "^0.21"
 lazy_static = "1.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/heim-common/Cargo.toml
+++ b/heim-common/Cargo.toml
@@ -20,7 +20,7 @@ uom = { version = "0.31.1", default-features = false, features = ["autoconvert",
 backtrace = { version = "^0.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.21"
+nix = "^0.22"
 lazy_static = "1.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/heim-common/src/errors.rs
+++ b/heim-common/src/errors.rs
@@ -362,13 +362,6 @@ impl From<convert::Infallible> for Error {
 #[cfg(unix)]
 impl From<nix::Error> for Error {
     fn from(e: nix::Error) -> Self {
-        let inner = match e {
-            nix::Error::Sys(errno) => io::Error::from_raw_os_error(errno as i32),
-            nix::Error::InvalidPath => io::Error::new(io::ErrorKind::InvalidInput, e),
-            nix::Error::InvalidUtf8 => io::Error::new(io::ErrorKind::InvalidData, e),
-            nix::Error::UnsupportedOperation => io::Error::new(io::ErrorKind::Other, e),
-        };
-
-        Error::from(inner)
+        Error::from(io::Error::from(e))
     }
 }

--- a/heim-cpu/src/sys/linux/count/physical.rs
+++ b/heim-cpu/src/sys/linux/count/physical.rs
@@ -8,7 +8,7 @@ use heim_runtime as rt;
 
 async fn topology() -> Result<u64> {
     rt::spawn_blocking(|| {
-        let path = rt::linux::sysfs_root().join("devices/system/cpu/cpu[0-9]/topology/core_id");
+        let path = rt::linux::sysfs_root().join("devices/system/cpu/cpu*/topology/core_id");
         let entries =
             glob::glob(path.display().to_string().as_str()).expect("Invalid glob pattern");
         let mut acc = HashSet::<u64>::new();

--- a/heim-host/src/os/linux.rs
+++ b/heim-host/src/os/linux.rs
@@ -5,8 +5,8 @@ use std::net::IpAddr;
 use crate::Pid;
 
 cfg_if::cfg_if! {
-    // aarch64-unknown-linux-gnu has different type
-    if #[cfg(all(target_arch = "aarch64", not(target_family = "musl")))] {
+    // aarch64-unknown-linux-gnu and s390x-unknown-linux-gnu has different type
+    if #[cfg(any(target_arch = "s390x",all(target_arch = "aarch64", not(target_family = "musl"))))] {
         /// User session ID.
         pub type SessionId = i64;
     } else {

--- a/heim-memory/src/os/linux.rs
+++ b/heim-memory/src/os/linux.rs
@@ -31,6 +31,9 @@ pub trait MemoryExt {
     ///
     /// This is memory that has not been recently used and can be reclaimed for other purposes.
     fn inactive(&self) -> Information;
+
+    /// Memory which is waiting to get written back to the disk.
+    fn dirty(&self) -> Information;
 }
 
 #[cfg(target_os = "linux")]
@@ -67,5 +70,9 @@ impl MemoryExt for Memory {
 
     fn inactive(&self) -> Information {
         self.as_ref().inactive()
+    }
+
+    fn dirty(&self) -> Information {
+        self.as_ref().dirty()
     }
 }

--- a/heim-memory/src/sys/linux/memory.rs
+++ b/heim-memory/src/sys/linux/memory.rs
@@ -15,6 +15,7 @@ pub struct Memory {
     active: Information,    // Active
     inactive: Information,  // Inactive
     shared: Information,    // Shmem
+    dirty: Information,     // Dirty
 }
 
 impl Memory {
@@ -42,6 +43,10 @@ impl Memory {
     pub fn shared(&self) -> Information {
         self.shared
     }
+
+    pub fn dirty(&self) -> Information {
+        self.dirty
+    }
 }
 
 impl FromStr for Memory {
@@ -56,7 +61,7 @@ impl FromStr for Memory {
             // we do not need that key at all
             let first_bytes = &line.as_bytes()[..2];
             match first_bytes {
-                b"Me" | b"Ac" | b"In" | b"Bu" | b"Ca" | b"Sh" => {}
+                b"Me" | b"Ac" | b"In" | b"Bu" | b"Ca" | b"Sh" | b"Di" => {}
                 _ => continue,
             };
 
@@ -70,6 +75,7 @@ impl FromStr for Memory {
                 Some("Active") => &mut memory.active,
                 Some("Inactive") => &mut memory.inactive,
                 Some("Shmem") => &mut memory.shared,
+                Some("Dirty") => &mut memory.dirty,
                 _ => continue,
             };
 

--- a/heim-memory/tests/smoke.rs
+++ b/heim-memory/tests/smoke.rs
@@ -22,6 +22,7 @@ async fn smoke_memory() {
         let _ = mem.shared();
         let _ = mem.active();
         let _ = mem.inactive();
+        let _ = mem.dirty();
     }
 
     #[cfg(target_os = "macos")]

--- a/heim-net/Cargo.toml
+++ b/heim-net/Cargo.toml
@@ -19,7 +19,7 @@ macaddr = "1.0"
 libc = "^0.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.21"
+nix = "^0.22"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["iphlpapi"]}

--- a/heim-net/Cargo.toml
+++ b/heim-net/Cargo.toml
@@ -19,7 +19,7 @@ macaddr = "1.0"
 libc = "^0.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.22"
+nix = "^0.23"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["iphlpapi"]}

--- a/heim-net/Cargo.toml
+++ b/heim-net/Cargo.toml
@@ -19,7 +19,7 @@ macaddr = "1.0"
 libc = "^0.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = "^0.20"
+nix = "^0.21"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["iphlpapi"]}


### PR DESCRIPTION
This updates the dependency on nix to 0.23. There was only one API change that had to be dealt with when moving to 0.22.

Takes the place of #339 