### PR TITLE
heim-cpu: fix glob pattern to support more than 10 cpus

### DIFF
--- a/heim-cpu/src/sys/linux/count/physical.rs
+++ b/heim-cpu/src/sys/linux/count/physical.rs
@@ -8,7 +8,7 @@ use heim_runtime as rt;
 
 async fn topology() -> Result<u64> {
     rt::spawn_blocking(|| {
-        let path = rt::linux::sysfs_root().join("devices/system/cpu/cpu[0-9]/topology/core_id");
+        let path = rt::linux::sysfs_root().join("devices/system/cpu/cpu*/topology/core_id");
         let entries =
             glob::glob(path.display().to_string().as_str()).expect("Invalid glob pattern");
         let mut acc = HashSet::<u64>::new();


### PR DESCRIPTION
The previous glob pattern matched only single-digit CPU numbers. I stumbled across this because [vector](https://vector.dev) was not showing more than 10 (the ones that match 0-9) physical cpus using its "host_metrics" source.

As fix, the glob pattern is changed to this: ```devices/system/cpu/cpu*/topology/core_id```.

Unfortunately ```glob::glob()``` doesn't support "one or more of this character" like a regex would.
So this fix only works until linux adds files that match ```cpu*/topology/core_id``` but not ```cpu[0-9]+/topology/core_id```.
I consider that highly unlikely. But I there are ways to ensure this never bites us:

- add a regex to filter the glob results
- concatenate three globs: ```.../cpu[0]/...```, ```.../cpu[0]/...``` and ```.../cpu[0][0][0]/...```
- *added later* switch to the [globset crate](https://github.com/heim-rs/heim/pull/366), and add those three globs to a globset
- other suggestions?